### PR TITLE
Fixed possible nil crash

### DIFF
--- a/lib/puppet/reports/splunk.rb
+++ b/lib/puppet/reports/splunk.rb
@@ -22,7 +22,7 @@ Puppet::Reports.register_report(:splunk) do
 
   def process
     output = self.logs.inject([]) do |a, log|
-      a.concat(["#{log.source}: #{log.message}"])
+      a.concat(["#{log.source}: #{log.message.gsub(/%/, '%%')}"])
     end
 
     @host = self.host

--- a/lib/puppet/reports/splunk.rb
+++ b/lib/puppet/reports/splunk.rb
@@ -28,7 +28,11 @@ Puppet::Reports.register_report(:splunk) do
     @host = self.host
     self.status == 'failed' ? @failed = true : @failed = false
     @start_time = self.logs.first.time
-    @elapsed_time = metrics["time"]["total"]
+    if metrics["time"]
+      @elapsed_time = metrics["time"]["total"] 
+    else
+      @elapsed_time = self.logs.last.time - self.logs.first.time
+    end
 
     if metrics["resources"]
       @resource_count = {


### PR DESCRIPTION
I was getting a report with empty metrics when Error while evaluating a Function Call, this would cause a failure: Report processor failed: undefined method `[]' for nil:NilClass
